### PR TITLE
install pypdf2 from ind9 git repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ opencv-python>=3.4.2.17
 openpyxl>=2.5.8
 pandas>=0.23.4
 pdfminer.six>=20170720
--e git+https://github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF2_FIX
 scikit-learn>=0.21.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF2_FIX
+-e git+https://github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF2-1.27.0
 click>=6.7
 matplotlib>=2.2.3
 numpy>=1.13.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e git+https://github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF2_FIX
 click>=6.7
 matplotlib>=2.2.3
 numpy>=1.13.3

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires = [
     'openpyxl>=2.5.8',
     'pandas>=0.23.4',
     'pdfminer.six>=20170720',
-    'PyPDF2_FIX'
+    'PyPDF2>=1.27.0'  # bumped up version from forked repo
 ]
 
 cv_requires = [
@@ -56,7 +56,7 @@ def setup_package():
                     license=about['__license__'],
                     packages=find_packages(exclude=('tests',)),
                     install_requires=requires,
-                    dependency_links=['git+ssh://git@github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF2_FIX-0'],
+                    dependency_links=['git+ssh://git@github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF2-1.27.0-0'],
                     extras_require={
                         'all': all_requires,
                         'cv': cv_requires,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires = [
     'openpyxl>=2.5.8',
     'pandas>=0.23.4',
     'pdfminer.six>=20170720',
-    'PyPDF2 @ git+https://github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF'  # bumped up version from forked repo
+    'PyPDF2 @ git+https://github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF2'  # bumped up version from forked repo
 ]
 
 cv_requires = [

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ requires = [
     'numpy>=1.13.3',
     'openpyxl>=2.5.8',
     'pandas>=0.23.4',
-    'pdfminer.six>=20170720'
+    'pdfminer.six>=20170720',
+    'PyPDF2_FIX'
 ]
 
 cv_requires = [
@@ -55,7 +56,7 @@ def setup_package():
                     license=about['__license__'],
                     packages=find_packages(exclude=('tests',)),
                     install_requires=requires,
-                    dependency_links=['https://github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF2_FIX'],
+                    dependency_links=['git+ssh://git@github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF2_FIX-0'],
                     extras_require={
                         'all': all_requires,
                         'cv': cv_requires,

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requires = [
     'openpyxl>=2.5.8',
     'pandas>=0.23.4',
     'pdfminer.six>=20170720',
-    'PyPDF2>=1.27.0'  # bumped up version from forked repo
+    'PyPDF2 @ git+https://github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF'  # bumped up version from forked repo
 ]
 
 cv_requires = [
@@ -56,7 +56,6 @@ def setup_package():
                     license=about['__license__'],
                     packages=find_packages(exclude=('tests',)),
                     install_requires=requires,
-                    dependency_links=['git+ssh://git@github.com/ind9/PyPDF2.git@BugFix#egg=PyPDF2-1.27.0-0'],
                     extras_require={
                         'all': all_requires,
                         'cv': cv_requires,


### PR DESCRIPTION
Hi @ashwanthkumar-avalara we are trying to install pypdf2 from a forked repo `https://github.com/ind9/PyPDF2/tree/BugFix`.

1. Initially we were trying to modify the requirements.txt but notices that the installation of camelot was done using the setup.py

2. Based on these comments https://github.com/pypa/pip/issues/3610#issuecomment-356687173 & https://github.com/pypa/pip/issues/2124#issuecomment-281234478 i came up with these PR.

3. Locally when we are installing the setup.py we are getting the following error. Seems the git clone is not working may be we need to pass the git_token as mentioned here https://github.com/pypa/pip/issues/2124#issuecomment-281235655. Can you please help us with this issue.

```Searching for PyPDF2_FIX
Doing git clone from https://github.com/ind9/PyPDF2.git to /var/folders/md/n05xdtvj3p95h42g5x9x05wc0000gp/T/easy_install-abknp38_/PyPDF2.git@BugFix
error: RPC failed; curl 56 LibreSSL SSL_read: SSL_ERROR_SYSCALL, errno 54
fatal: the remote end hung up unexpectedly
fatal: early EOF
fatal: index-pack failed
Checking out BugFix
sh: line 0: cd: /var/folders/md/n05xdtvj3p95h42g5x9x05wc0000gp/T/easy_install-abknp38_/PyPDF2.git@BugFix: No such file or directory
Reading https://pypi.org/simple/PyPDF2_FIX/
Reading https://pypi.org/simple/PyPDF2-FIX/
Couldn't retrieve index page for 'PyPDF2_FIX'
Scanning index of all packages (this may take a while)
Reading https://pypi.org/simple/
Doing git clone from https://github.com/ind9/PyPDF2.git to /var/folders/md/n05xdtvj3p95h42g5x9x05wc0000gp/T/easy_install-abknp38_/PyPDF2.git@BugFix
Checking out BugFix
Best match: PyPDF2-FIX [unknown version]
Processing PyPDF2.git@BugFix
Writing /var/folders/md/n05xdtvj3p95h42g5x9x05wc0000gp/T/easy_install-abknp38_/PyPDF2.git@BugFix/setup.cfg
Running setup.py -q bdist_egg --dist-dir /var/folders/md/n05xdtvj3p95h42g5x9x05wc0000gp/T/easy_install-abknp38_/PyPDF2.git@BugFix/egg-dist-tmp-peh7vqwj
zip_safe flag not set; analyzing archive contents...
Copying PyPDF2-1.26.0-py3.7.egg to /usr/local/lib/python3.7/site-packages
Adding PyPDF2 1.26.0 to easy-install.pth file

Installed /usr/local/lib/python3.7/site-packages/PyPDF2-1.26.0-py3.7.egg
error: The 'PyPDF2_FIX' distribution was not found and is required by camelot-py```

