### PR TITLE
Exposing bounding box coordinates for the extracted table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _build/
 .vscode
 
 venv
+src/

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -403,7 +403,7 @@ class Lattice(BaseParser):
             bbox = self._group_rows(bbox, 0.0)
             text_line_list = [' '.join([b.get_text().strip() for b in i]) for i in bbox]
             result.append((bbox, '\n'.join(text_line_list)))
-            result.append(table.df)
+            result.append(((table._bbox, table.cells), table.df))
             p_h = y1
         bbox = text_in_bbox((x1, 0.0, p_w, p_h), self.horizontal_text)
         bbox.sort(key=lambda x: (-x.y0, x.x0))

--- a/camelot/parsers/stream.py
+++ b/camelot/parsers/stream.py
@@ -438,6 +438,6 @@ class Stream(BaseParser):
             cols, rows = self._generate_columns_and_rows(table_idx, tk)
             table = self._generate_table(table_idx, cols, rows)
             table._bbox = tk
-            _tables.append(table)
+            _tables.append(((table._bbox, table.cells), table.df))
 
         return _tables


### PR DESCRIPTION
- This fix exposes extracted dataframe along with its bounding box coordinates and cell level coordinates which in turn is used by Generic Table Parser.